### PR TITLE
Feature/issue28 make registration endpoint work

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,22 @@
+import constants from './constants.js';
+
+export default function getTokenFromBackendEndpoint(username, password) {
+
+    fetch(constants.AUTH_TOKEN_URL, {
+        method: 'POST',
+        mode: 'cors',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({username, password}),
+    })
+        .then(res => res.json())
+        .then((json) => {
+            console.log(json)
+            window.sb.tokenresult = json
+        })
+        .catch((err) => { console.log(err) })
+}
+
+if (!window.sb) window.sb = {}
+window.sb.getToken = getTokenFromBackendEndpoint;

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,9 +1,10 @@
 
 const BACKEND_URL_BASE = 'http://localhost:8080'
 const URL_USER = BACKEND_URL_BASE+"/users"
+const AUTH_TOKEN_URL = BACKEND_URL_BASE+"/auth/token"
 
 export const constants = {
-    BACKEND_URL_BASE, URL_USER
+    BACKEND_URL_BASE, URL_USER, AUTH_TOKEN_URL
 }
 export default constants;
 

--- a/js/registering.js
+++ b/js/registering.js
@@ -1,4 +1,5 @@
 import constants from './constants.js';
+import getTokenFromBackendEndpoint from './auth.js'
 
 export default function registerForm2registrationJSONSend() {
     /***
@@ -28,12 +29,8 @@ export default function registerForm2registrationJSONSend() {
 
         Note: this works by creating local scope variables named like the fields noted int the "let" statement.
      ***/
-    //(()=>
-    {
-        let {name, password, email, gender, firstname, lastname, country} = data_as_object;
-        data_to_send_to_register_endpoint = {username:name, password, email, gender, firstname, lastname, country};
-    }
-    //)();
+    let {name, password, email, gender, firstname, lastname, country} = data_as_object;
+    data_to_send_to_register_endpoint = {username:name, password, email, gender, firstname, lastname, country};
 
     fetch(constants.URL_USER, {
         method: 'POST',
@@ -45,8 +42,10 @@ export default function registerForm2registrationJSONSend() {
     })
         .then(res => res.json())
         .then((json) => {
-            console.log(res)
+            console.log(json)
             window.sb.registration_result = json
+            // if registering worked -> try logging in = getting a token
+            getTokenFromBackendEndpoint(name,password)
         })
     .catch((err) => { console.log(err) })
 }


### PR DESCRIPTION
* tweak code to send the data required by new endpoint spec in same-name branch in backend.
* add js code for asking the auth/token endpoint for a token.
* do that too, right after registration (when we have the user/pass still in scope :)
* hopefully helpful and explanatory comment above the "form-data to registration-dta translation" kudos evleh 